### PR TITLE
Improvement to diagonal links when using vertical orientation

### DIFF
--- a/js/familytree.js
+++ b/js/familytree.js
@@ -748,21 +748,21 @@ class FTDrawer {
     };
 
     static default_link_path_func(s, d) {
-		function vertical_s_bend(s, d) {
-			// Creates a diagonal curve fit for vertical oriented trees
-			return `M ${s.x} ${s.y} 
-			C ${s.x} ${(s.y + d.y) / 2},
-			${d.x} ${(s.y + d.y) / 2},
-			${d.x} ${d.y}`
-		}
+        function vertical_s_bend(s, d) {
+            // Creates a diagonal curve fit for vertical oriented trees
+            return `M ${s.x} ${s.y} 
+            C ${s.x} ${(s.y + d.y) / 2},
+            ${d.x} ${(s.y + d.y) / 2},
+            ${d.x} ${d.y}`
+        }
 
-		function horizontal_s_bend(s, d) {
-			// Creates a diagonal curve fit for horizontally oriented trees
+        function horizontal_s_bend(s, d) {
+            // Creates a diagonal curve fit for horizontally oriented trees
             return `M ${s.x} ${s.y}
             C ${(s.x + d.x) / 2} ${s.y},
               ${(s.x + d.x) / 2} ${d.y},
               ${d.x} ${d.y}`
-		}
+        }
         return this._orientation == "vertical" ? vertical_s_bend(s, d) : horizontal_s_bend(s, d);
     }
 

--- a/js/familytree.js
+++ b/js/familytree.js
@@ -749,7 +749,7 @@ class FTDrawer {
 
     static default_link_path_func(s, d) {
         function vertical_s_bend(s, d) {
-            // Creates a diagonal curve fit for vertical oriented trees
+            // Creates a diagonal curve fit for vertically oriented trees
             return `M ${s.x} ${s.y} 
             C ${s.x} ${(s.y + d.y) / 2},
             ${d.x} ${(s.y + d.y) / 2},

--- a/js/familytree.js
+++ b/js/familytree.js
@@ -748,14 +748,22 @@ class FTDrawer {
     };
 
     static default_link_path_func(s, d) {
-        function diagonal(s, d) {
-            // Creates a curved (diagonal) path from parent to the child nodes
+		function vertical_s_bend(s, d) {
+			// Creates a diagonal curve fit for vertical oriented trees
+			return `M ${s.x} ${s.y} 
+			C ${s.x} ${(s.y + d.y) / 2},
+			${d.x} ${(s.y + d.y) / 2},
+			${d.x} ${d.y}`
+		}
+
+		function horizontal_s_bend(s, d) {
+			// Creates a diagonal curve fit for horizontally oriented trees
             return `M ${s.x} ${s.y}
             C ${(s.x + d.x) / 2} ${s.y},
               ${(s.x + d.x) / 2} ${d.y},
               ${d.x} ${d.y}`
-        }
-        return diagonal(s, d);
+		}
+        return this._orientation == "vertical" ? vertical_s_bend(s, d) : horizontal_s_bend(s, d);
     }
 
     link_path(link_path_func) {


### PR DESCRIPTION
When trying out the vertical orientation, I noticed that the diagonal s-bends still start out horizontally instead of vertically. 

Before fix:
![before change](https://user-images.githubusercontent.com/13008236/183114826-e1b4666d-7b79-404b-aa90-d03991c569fa.png)

After fix: 
![after change](https://user-images.githubusercontent.com/13008236/183114860-43892175-92fe-44fa-bf6c-1c87a68c9a02.png)

