### PR TITLE
fix: prevent addLink duplicates

### DIFF
--- a/src/familytree.ts
+++ b/src/familytree.ts
@@ -251,6 +251,9 @@ export class FamilyTree {
    */
   public addLink(sourceId: string, targetId: string, render: boolean = true) {
     const link = [sourceId, targetId] as [string, string];
+    // prevent duplicates
+    if (this.data.links.some(([s, t]) => s === sourceId && t === targetId)) return;
+
     this.data.links.push(link);
     if (render) this.reimportData();
   }


### PR DESCRIPTION
If a user adds the same links more than once the data structure gets dirty with duplicates.
This patch prevents it.